### PR TITLE
Add SUSE's VPN profiles

### DIFF
--- a/autoinst.xml
+++ b/autoinst.xml
@@ -797,6 +797,8 @@
       <package>aaa_base</package>
       <package>yast2-country</package>
       <package>NetworkManager-applet</package>
+      <package>NetworkManager-openconnect-profile-SUSE-VPN</package>
+      <package>NetworkManager-openvpn-profile-SUSE-VPN</package>
       <package>mdadm</package>
     </packages>
     <patterns t="list">


### PR DESCRIPTION
depends on https://build.opensuse.org/request/show/987757